### PR TITLE
Emulate writing of toy tags

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,6 +40,7 @@ function createCharacter(id, uid){
 tp._hook(tp.CMD_WRITE, (req, res) => {
 	var ind = req.payload[0];
 	var page = req.payload[1];
+	console.log('REQUEST (CMD_WRITE): index:', ind, 'page', page);
 	res.payload = new Buffer('00', 'hex');
 	var token = tp._tokens.find(t => t.index == ind);
 	if (token)

--- a/index.js
+++ b/index.js
@@ -35,6 +35,17 @@ function createCharacter(id, uid){
 	return token;
 }
 
+
+//When the game calls 'CMD_WRITE', writes the given data to the toytag in the top position.
+tp._hook(tp.CMD_WRITE, (req, res) => {
+	var ind = req.payload[0];
+	var page = req.payload[1];
+	res.payload = new Buffer('00', 'hex');
+	var token = tp._tokens.find(t => t.index == ind);
+	if (token)
+		req.payload.copy(token.token, 4 * page, 2, 6);
+});
+
 app.use(express.json());
 
 app.get('/', (request, response) => {


### PR DESCRIPTION
Added a hook to the toypad that writes data to the tag in the top position when prompted. The data is saved, but in the current state this data is immediately forgotten if the tag is moved. However it does allow you to pass forced vehicle builds in the story and levels.