### PR TITLE
Modified node-gyp version in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Allows you to connect an emulated Toy Pad to your PC or video-game console.
    
    nvm install 11
    sudo setcap cap_net_bind_service=+ep `readlink -f \`which node\``
-   npm install --global node-gyp@latest
+   npm install --global node-gyp@8.4.1
    npm config set node_gyp $(npm prefix -g)/lib/node_modules/node-gyp/bin/node-gyp.js
    
    cd LD-ToyPad-Emulator


### PR DESCRIPTION
The latest version of node-gyp (9.0.0) no longer supports node 11, causing 'npm install' to fail. Therefore I suggest explicitly specifying node-gyp version 8.4.1 (last version released before 9.0.0)