### PR TITLE
Allow tags to be dropped on the same space they were picked up from

### DIFF
--- a/server/index.html
+++ b/server/index.html
@@ -376,23 +376,7 @@
 					}
 					//If moving between spaces on the Toy Pad, remove from previous space and place in new one.
 					else {
-						var content = { uid: ui.item.attr('data-uid'), id: ui.item.attr('data-id'), position: $this.attr('padNum'), index: $this.attr('padIndex') }
-						console.log(ui.sender.attr('padIndex'))
-						$.ajax({
-							method: 'DELETE',
-							contentType: 'application/json',
-							url: '/remove',
-							data: JSON.stringify({ index: parseInt(ui.sender.attr('padIndex')), uid: ui.item.attr('data-uid') })
-						}).done(function () {
-							setTimeout(function () {
-								$.ajax({
-									method: 'POST',
-									contentType: 'application/json',
-									url: '/characterPlace',
-									data: JSON.stringify(content)
-								})
-							}, 500);
-						})
+						updateToyPadPosition(ui.item.attr('data-uid'), ui.item.attr('data-id'), $this.attr('padNum'), ui.sender.attr('padIndex'), $this.attr('padIndex'));
 					}
 				}
 			});
@@ -514,6 +498,26 @@
 						else if (item.index != '-1')
 							$('#toypad' + item.index).append('<li class=item draggable=true data-type=' + item.type + ' data-id= ' + item.id + ' data-uid=' + item.uid + ' pad=' + item.pad + '><h3>' + item.name + '</h3></li>');
 					});
+				});
+			}
+
+			function updateToyPadPosition(uid, id, position, currentIndex, newIndex)
+			{
+				console.log(currentIndex);
+				$.ajax({
+					method: 'DELETE',
+					contentType: 'application/json',
+					url: '/remove',
+					data: JSON.stringify({ index:  parseInt(currentIndex), uid: uid })
+				}).done(function () {
+					setTimeout(function () {
+						$.ajax({
+							method: 'POST',
+							contentType: 'application/json',
+							url: '/characterPlace',
+							data: JSON.stringify({uid: uid, id: id, position: position, index: newIndex})
+						})
+					}, 500);
 				});
 			}
 

--- a/server/index.html
+++ b/server/index.html
@@ -338,15 +338,33 @@
 				scroll: true,
 				scrollSensitivity: 40,
 				scrollSpeed: 10,
-				start: function (event) {
+				start: function (event, ui) {
 					$('html, body').animate({ scrollTop: $(document).height() }, 500);
+
+					// Store the starting pad number and index so we can determine when releasing the tag if it was released in the same space
+					ui.item.attr('previousPadNum', ui.item.closest('.box').attr('padNum'));
+					ui.item.attr('previousPadIndex', ui.item.closest('.box').attr('padIndex'));
 				},
-				stop: function (event) {
-					//$('html, body').animate({ scrollTop: 0 }, 500);
+				stop: function (event, ui) {
+					var parentBox = ui.item.closest('.box');
+					var previousPadNum = ui.item.attr('previousPadNum');
+					var newPadNum = parentBox.attr('padNum');
+					var previousPadIndex = ui.item.attr('previousPadIndex');
+					var newPadIndex = parentBox.attr('padIndex');
+
+					// If moving to the same space on the Toy Pad, remove and place in the current space
+					if (previousPadNum != -1 &&
+						previousPadNum != -2 &&
+						previousPadNum == newPadNum &&
+						previousPadIndex == newPadIndex) {
+							updateToyPadPosition(ui.item.attr('data-uid'), ui.item.attr('data-id'), newPadNum, newPadIndex, newPadIndex);
+					}
+
+					ui.item.removeAttr('previousPadNum');
+					ui.item.removeAttr('previousPadIndex');
 				},
 				receive: function (event, ui) {
 					var $this = $(this);
-					console.log()
 
 					if ($this.attr('id') == "remove-tokens") {
 						socket.emit('deleteToken', ui.item.attr('data-uid'));


### PR DESCRIPTION
This PR updates the sortable event handlers to allow tags to be dragged into the same space they started in. This addresses point 1 of #49, and #24. I didn't implement this as a double click as suggested in #24 as it does work well with sortable or on touchscreens.

This also mitigates some of the sync issues caused by rapidly dragging between spaces on the Toy Pad, which can remove a tag before it has been placed in its new location. It doesn't prevent it, but it is now much less likely to occur due to the fact that returning a tag to the same space was the most likely reason I've found to move a tag twice in quick succession.