### PR TITLE
JSON schema check

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,3 +29,18 @@ jobs:
       # - run: npm run build --if-present
       # - run: npm test
 
+  verify-json-validation:
+    
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        file-name: [charactermap, tokenmap]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Validate JSON ${{ matrix.file-name }}.json
+        uses: docker://orrosenblatt/validate-json-action:latest
+        env:
+          INPUT_SCHEMA: /test/${{ matrix.file-name }}_schema.json
+          INPUT_JSONS: /server/json/${{ matrix.file-name }}.json

--- a/test/charactermap_schema.json
+++ b/test/charactermap_schema.json
@@ -1,0 +1,30 @@
+{
+    "type": "array",
+    "title": "Root Schema",
+    "minItems": 1,
+    "uniqueItems": true,
+    "items": {
+        "type": "object",
+        "title": "A Schema",
+        "minProperties": 4,        
+        "additionalProperties": false,
+        "properties": {
+            "id": {
+                "type": "integer",
+                "title": "The id Schema"
+            },
+            "name": {
+                "type": "string",
+                "title": "The name Schema"
+            },
+            "world": {
+                "type": "string",
+                "title": "The world Schema"
+            },
+            "abilities": {
+                "type": "string",
+                "title": "The abilities Schema"
+            }
+        }
+    }
+}

--- a/test/tokenmap_schema.json
+++ b/test/tokenmap_schema.json
@@ -1,0 +1,38 @@
+{
+    "type": "array",
+    "title": "Root Schema",
+    "minItems": 1,
+    "uniqueItems": true,
+    "items": {
+        "type": "object",
+        "title": "A Schema",
+        "minProperties": 6,
+        "additionalProperties": false,
+        "properties": {
+            "id": {
+                "type": "integer",
+                "title": "The id Schema"
+            },
+            "upgrademap": {
+                "type": "integer",
+                "title": "The upgrademap Schema"
+            },
+            "rebuild": {
+                "type": "integer",
+                "title": "The rebuild Schema"
+            },
+            "name": {
+                "type": "string",
+                "title": "The name Schema"
+            },
+            "world": {
+                "type": "string",
+                "title": "The world Schema"
+            },
+            "abilities": {
+                "type": "string",
+                "title": "The abilities Schema"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Used one of GH Actions to add schema validation for charactermap, tokenmap files.
Intent is to avoid any errors, typos in such big JSON files. So each PR and commit should have `smoke check`  statuses.

Built schemas with constructors and adjusted them manually.
Feel free to reorganize  directory structure your way if needed.

Last step to close #98 

P.S. Probably node tests is the better place for these checks, but it's easier for me to implement it this way.

P.S.2 Will keep an eye on Action. It uses several deprecated commands. Will migrate to something else if it's not maintained properly.
