### PR TITLE
Correct the USB cable listed in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Allows you to connect an emulated Toy Pad to your PC or video-game console.
 #### Prerequisites
 * **Raspberry Pi Zero W** ($10) or similar single board computer with Network support
   * **NOTE**: Will NOT work with Rapsberry Pi: 2, 3, 3A, 3A+, 3B, 3B+. These models lack the ability to become a usb gadget.
-* **USB A to micro USB A cable** that supports data transmission (e. g. your phone's charging cable)
+* **USB Type-A to micro-USB 2.0 Type-B cable** that supports data transmission (e. g. your phone's charging cable)
 * 2 GB+ Micro SD card
 * Internet connection on your PC and single board computer
 


### PR DESCRIPTION
I know this is really more of a nitpick, but the Pi Zero (2) W uses a 'micro-USB 2.0 Type-B' connector, not 'micro USB A' -- I've attached a picture showing the difference as well.


![image](https://upload.wikimedia.org/wikipedia/commons/8/82/USB_2.0_and_3.0_connectors.svg)
<sup>[image source [CC BY-SA 3.0]](https://commons.wikimedia.org/wiki/File:USB_2.0_and_3.0_connectors.svg)</sup>
