### PR TITLE
color filter - green fixed for hack minigame

### DIFF
--- a/index.js
+++ b/index.js
@@ -263,6 +263,11 @@ function RGBToHex(r, g, b) {
 
 		//locate keystone (too many possible values to find by hand. need help here)
 
+		//green (hack minigame)
+		case "#003700":
+			hex = "#00ff00";
+			break;
+
 		//other
 		case "#ff6e18":
 			hex = "#ffffff";


### PR DESCRIPTION
green by default is very dark in hack minigame. it outputs a different value that wasnt in the switch code
this pull adds it to the code fixing it