### PR TITLE
pipeline-fix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
   build:
 
     # runs-on: ubuntu-latest # node 11 fails with Python 2 exception for print
-    runs-on: ubuntu-20.04 
+    runs-on: ubuntu-22.04 
 
     strategy:
       matrix:


### PR DESCRIPTION
Changing GH runner image version to 22.04.
Previous version 20.04 had been deprecated.

There is a compatibility issue: ubuntu 22.04 vs Node 11.
Should I exclude Node 11 from pipeline?