### PR TITLE
Update docs to use Bullseye 

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Allows you to connect an emulated Toy Pad to your PC or video-game console.
 
 #### Installation
 
-1. Flash a recent edition of Raspberry Pi OS Lite (either 32-bit for the Zero (W) or 64-bit for RPi 4/5)
+1. Flash Raspberry Pi OS Bullseye (Lite, either 32-bit for the Zero (W) or 64-bit for RPi 4/5) on a Micro-SD card.
 
 2. Connect your device to your PC via USB cable (don't use the port on the edge of the Pi Zero!).
 


### PR DESCRIPTION
In #298 we could somewhat figure out that the transport errors seem to come from a broken USB device setup on newer Rasperry Pi OS versions. It seems to be working with Bullseye, so until further tests can be done, recommending Bullseye is probably the best option.